### PR TITLE
fix: 修复预览问题 cannot read property 'x' of undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,8 @@ const VuePreview = {
             return params
           }
           const openPhotoSwipe = function (index, galleryElement, disableAnimation, fromURL) {
-            let pswpElement = document.querySelectorAll('.pswp')[0]
+            let gid = (galleryElement.getAttribute('data-pswp-uid') - 1) || 0
+            let pswpElement = document.querySelectorAll('.pswp')[gid]
             let gallery
             let photoSwipeOptions
             let items


### PR DESCRIPTION
【问题描述】同一个路由下，切换tab，展示两个不同组件，组件里都用该图片预览功能，第一个组件可以正常预览，第二个不能预览